### PR TITLE
Restart yukid once docker restart

### DIFF
--- a/dist/yukid.service
+++ b/dist/yukid.service
@@ -2,6 +2,7 @@
 Description=Sync Local Repos With Remote
 After=docker.service
 Requires=docker.service
+PartOf=docker.serivce
 
 [Service]
 User=mirror


### PR DESCRIPTION
xtom 的机器在更新 docker 后，yukid 会自动挂掉。 `PartOf` 参数用于触发 yukid 跟随 docker 重启。

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/5450996/36544215-1e9b657e-1810-11e8-8288-63452319a0bc.png">
