### PR TITLE
fix(server): add BindIP with cron job

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -167,6 +167,7 @@ func (s *Server) newJob(name string) cron.FuncJob {
 			NamePrefix: s.config.NamePrefix,
 			Name:       name,
 			MountDir:   !IsTest,
+			BindIP:     s.config.BindIP,
 		})
 		if err != nil {
 			s.logger.WithField("repo", name).Errorln(err)


### PR DESCRIPTION
由于部分镜像的上游服务器设置了白名单，BindIP配置错误会导致同步失败。

CentOS 已经超过10天没更新成功了。